### PR TITLE
setup automation for image build on release

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,1 +1,8 @@
 check: []
+build:
+  build-strategy: Dockerfile
+  dockerfile-path: Dockerfile
+  registry: quay.io
+  registry-org: open-services-group
+  registry-project: peribolos-as-service
+  registry-secret: osg-pusher-secret

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Peribolos as a service
 
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/open-services-group/peribolos-as-a-service/blob/main/LICENSE)
+![GitHub Tag](https://img.shields.io/github/v/tag/open-services-group/peribolos-as-a-service?style=plastic)
+[![Docker Repository on Quay](https://quay.io/repository/open-services-group/peribolos-as-service/status "Docker Repository on Quay")](https://quay.io/repository/open-services-group/peribolos-as-service)
+
 Learning exercise for OSG in how to make a managed service.
 
 In this exercise we would like to take a [Peribolos](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/peribolos) tool and turn it into an automated, subscribable, and consumable service for declarative github organization management.


### PR DESCRIPTION
setup automation for image build on release
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Details:
- This would set image build automatically on releases.
- PR images can also be built. 

Reference:
https://quay.io/repository/open-services-group/peribolos-as-service?tab=tags