### PR TITLE
feat: handle org config dump if not present

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 ---
+exclude: '.patch'
 repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.11

--- a/manifests/base/peribolos-dump-config.yaml
+++ b/manifests/base/peribolos-dump-config.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: dump-config
+  name: peribolos-dump-config
 spec:
   params:
   - name: REPO_NAME
@@ -10,15 +10,28 @@ spec:
     default: .github
   - name: INSTALLATION_ID
     type: string
-  - name: GIT_EMAIL
-    type: string
-  - name: GIT_NAME
-    type: string
   steps:
-    - name: dump-and-push-config
+    - name: dump-config
+      image: quay.io/skopecky/peribolos-fix
+      volumeMounts:
+        - mountPath: /mnt/shared
+          name: shared-data
+        - mountPath: /mnt/secret
+          name: github-token
+      env:
+        - name: ORG_NAME
+          valueFrom:
+            secretKeyRef:
+              name: peribolos-$(params.INSTALLATION_ID)
+              key: orgName
+      script: |
+        #!/bin/sh
+
+        peribolos --dump $ORG_NAME --github-token-path /mnt/secret/token > /mnt/shared/peribolos.yaml
+    - name: push-config
       image: quay.io/operate-first/opf-toolbox
       volumeMounts:
-        - mountPath: /var/lib/shared
+        - mountPath: /mnt/shared
           name: shared-data
       env:
         - name: GITHUB_TOKEN
@@ -31,21 +44,26 @@ spec:
             secretKeyRef:
               name: peribolos-$(params.INSTALLATION_ID)
               key: orgName
+        - name: APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: peribolos-as-service
+              key: app_id
       script: |
         #!/bin/bash
-        REPO_REMOTE="https://$GITHUB_TOKEN@github.com/$ORG_NAME/$(params.REPO_NAME)"
+        REPO_REMOTE="https://x-access-token:$GITHUB_TOKEN@github.com/$ORG_NAME/$(params.REPO_NAME)"
 
         DEFAULT_BRANCH=$( curl \
           -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: Bearer ${GITHUB_TOKEN}" \
           https://api.github.com/repos/$ORG_NAME/$(params.REPO_NAME) 2>/dev/null \
           | yq e '.default_branch' - | sed 's/\"//g' )
-        echo -n $DEFAULT_BRANCH > /var/lib/shared/default_branch
+        echo -n $DEFAULT_BRANCH > /mnt/shared/default_branch
 
         BRANCH_NAME="$(context.taskRun.name)"
 
-        git config --global user.email "$(params.GIT_EMAIL)"
-        git config --global user.name "$(params.GIT_NAME)"
+        git config --global user.email "$APP_ID+peribolos-service[bot]@users.noreply.github.com"
+        git config --global user.name "peribolos-service[bot]"
 
         mkdir repo
         cd repo
@@ -62,9 +80,7 @@ spec:
         fi
         git checkout -b $BRANCH_NAME
 
-        echo -n $GITHUB_TOKEN > token
-        echo "Dumping org config ..."
-        peribolos --dump $ORG_NAME --github-token-path token > peribolos.yaml
+        cp /mnt/shared/peribolos.yaml .
 
         echo "Commiting config to $BRANCH_NAME branch ..."
         git add peribolos.yaml
@@ -73,7 +89,7 @@ spec:
     - name: open-pr
       image: registry.access.redhat.com/ubi8/python-38:1-34.1599745032
       volumeMounts:
-        - mountPath: /var/lib/shared
+        - mountPath: /mnt/shared
           name: shared-data
       env:
       - name: GITHUB_TOKEN
@@ -98,7 +114,7 @@ spec:
 
         github_token = os.environ['GITHUB_TOKEN']
         org_name = os.environ['ORG_NAME']
-        default_branch = open("/var/lib/shared/default_branch", "r").read()
+        default_branch = open("/mnt/shared/default_branch", "r").read()
         repo_full_path = f"{org_name}/$(params.REPO_NAME)"
 
         open_pr_url = f"/repos/{repo_full_path}/pulls"
@@ -138,3 +154,10 @@ spec:
   volumes:
     - emptyDir: {}
       name: shared-data
+    - name: github-token
+      secret:
+          secretName: peribolos-$(params.INSTALLATION_ID)
+          items:
+            - key: token
+              path: token
+          optional: false

--- a/peribolos-fix/Dockerfile
+++ b/peribolos-fix/Dockerfile
@@ -1,0 +1,15 @@
+FROM registry.access.redhat.com/ubi8/go-toolset as builder
+# As of now the last commit, not downloading the latest becuase the patch might not work
+ARG COMMIT=83bf07dd99d23a5d6998490ec35240a4be895254
+
+USER root
+WORKDIR /peribolos
+RUN curl -L https://github.com/kubernetes/test-infra/tarball/$COMMIT | tar -xz --strip-components=1
+COPY peribolos.patch prow/cmd/peribolos
+RUN cd prow/cmd/peribolos && \
+patch -f -u main.go -i peribolos.patch && \
+CGO_ENABLED=0 go build -o /usr/bin/peribolos
+
+FROM registry.access.redhat.com/ubi8-micro
+
+COPY --from=builder /usr/bin/peribolos /usr/bin/peribolos

--- a/peribolos-fix/peribolos.patch
+++ b/peribolos-fix/peribolos.patch
@@ -1,0 +1,28 @@
+--- main.go	2022-04-20 16:32:38.283785115 +0200
++++ main-change.go	2022-04-20 16:34:58.502292974 +0200
+@@ -241,11 +241,6 @@
+ 	out.Metadata.DefaultRepositoryPermission = &drp
+ 	out.Metadata.MembersCanCreateRepositories = &meta.MembersCanCreateRepositories
+ 
+-	var runningAsAdmin bool
+-	runningAs, err := client.BotUser()
+-	if err != nil {
+-		return nil, fmt.Errorf("failed to obtain username for this token")
+-	}
+ 	admins, err := client.ListOrgMembers(orgName, github.RoleAdmin)
+ 	if err != nil {
+ 		return nil, fmt.Errorf("failed to list org admins: %w", err)
+@@ -254,13 +249,6 @@
+ 	for _, m := range admins {
+ 		logrus.WithField("login", m.Login).Debug("Recording admin.")
+ 		out.Admins = append(out.Admins, m.Login)
+-		if runningAs.Login == m.Login {
+-			runningAsAdmin = true
+-		}
+-	}
+-
+-	if !runningAsAdmin {
+-		return nil, fmt.Errorf("--dump must be run with admin:org scope token")
+ 	}
+ 
+ 	orgMembers, err := client.ListOrgMembers(orgName, github.RoleMember)


### PR DESCRIPTION
Resolves #9 
- Create a `Dockerfile` for custom `peribolos` binary that solves [this](https://github.com/open-services-group/peribolos-as-a-service/issues/9#issuecomment-1092861663) issue. This binary is then used in the updated `dump-config` task.
- Add an `CustomResourceApiCall` to create a taksrun for the `dump-config` task
