### PR TITLE
feat: split manifests into overlays

### DIFF
--- a/manifests/base/config-dump.yaml
+++ b/manifests/base/config-dump.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:

--- a/manifests/base/deployment-config.yaml
+++ b/manifests/base/deployment-config.yaml
@@ -2,24 +2,25 @@
 kind: DeploymentConfig
 apiVersion: apps.openshift.io/v1
 metadata:
-  name: peribolos-as-services
+  name: peribolos-as-service
 spec:
+  serviceAccountName: peribolos-as-service
   test: false
   replicas: 1
   selector:
     app.kubernetes.io/component: peribolos
     app.kubernetes.io/managed-by: sig-services
-    service: peribolos-as-services
+    service: peribolos-as-service
   template:
     metadata:
       labels:
         app.kubernetes.io/component: peribolos
         app.kubernetes.io/managed-by: sig-services
-        service: peribolos-as-services
+        service: peribolos-as-service
     spec:
-      serviceAccountName: peribolos-as-services
+      serviceAccountName: peribolos-as-service
       containers:
-        - name: peribolos-as-services
+        - name: peribolos-as-service
           image: peribolos-service-controller:latest
           imagePullPolicy: Always
           env:
@@ -27,17 +28,21 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: webhook_secret
-                  name: peribolos-as-services
+                  name: peribolos-as-service
             - name: APP_ID
               valueFrom:
                 secretKeyRef:
                   key: app_id
-                  name: peribolos-as-services
+                  name: peribolos-as-service
             - name: PRIVATE_KEY
               valueFrom:
                 secretKeyRef:
                   key: private_key
-                  name: peribolos-as-services
+                  name: peribolos-as-service
+            - name: NODE_ENV
+              value: "production"
+            - name: LOG_LEVEL
+              value: "debug"
           ports:
             - containerPort: 3000
               protocol: TCP

--- a/manifests/base/imagestream.yaml
+++ b/manifests/base/imagestream.yaml
@@ -1,4 +1,5 @@
-apiVersion: v1
+---
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: peribolos-service-controller

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -8,7 +9,10 @@ resources:
   - service-account.yaml
   - role.yaml
   - role-binding.yaml
+  - config-dump.yaml
+  - peribolos-run.yaml
+  - secret.yaml
 commonLabels:
-  app.kubernetes.io/name: peribolos-as-services
+  app.kubernetes.io/name: peribolos-as-service
   app.kubernetes.io/component: peribolos
   app.kubernetes.io/managed-by: sig-services

--- a/manifests/base/peribolos-run.yaml
+++ b/manifests/base/peribolos-run.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:

--- a/manifests/base/role-binding.yaml
+++ b/manifests/base/role-binding.yaml
@@ -1,3 +1,4 @@
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/manifests/base/role.yaml
+++ b/manifests/base/role.yaml
@@ -1,3 +1,4 @@
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/manifests/base/route.yaml
+++ b/manifests/base/route.yaml
@@ -2,8 +2,8 @@
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
-  name: peribolos-as-services
+  name: peribolos-as-service
 spec:
   to:
     kind: Service
-    name: peribolos-as-services
+    name: peribolos-as-service

--- a/manifests/base/secret.yaml
+++ b/manifests/base/secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: peribolos-as-service
+data:
+  app_id:
+  private_key:
+  webhook_secret:

--- a/manifests/base/service-account.yaml
+++ b/manifests/base/service-account.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: peribolos-as-services
+  name: peribolos-as-service

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -2,7 +2,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: peribolos-as-services
+  name: peribolos-as-service
 spec:
   ports:
     - name: webhook
@@ -12,4 +12,4 @@ spec:
   selector:
     app.kubernetes.io/component: peribolos
     app.kubernetes.io/managed-by: sig-services
-    service: peribolos-as-services
+    service: peribolos-as-service

--- a/manifests/overlays/dev/kustomization.yaml
+++ b/manifests/overlays/dev/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/env/3/value
+        value: development
+    target:
+      kind: DeploymentConfig
+      name: peribolos-as-service

--- a/manifests/overlays/test/kustomization.yaml
+++ b/manifests/overlays/test/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base


### PR DESCRIPTION
Resolves #34 
- Rename `peribolos-as-services` to `peribolos-as-service` for created reosources since I think the `s` at the end was a typo
- Create `json6902` patch for `dev/test` overlays to update `NODE_ENV` variable
- Update RBAC role to also include `deployments`, this is needed for the `depoyment-config` resource