### PR TITLE
Fix the image patch in CI

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -10,4 +10,4 @@ deploy:
   project-org: open-services-group
   project-name: peribolos-as-a-service
   image-name: peribolos-service-controller
-  overlay-contextpath: "manifests/imagestream.yaml"
+  overlay-contextpath: "manifests/overlays/prod/imagestream.yaml"

--- a/manifests/base/deployment-config.yaml
+++ b/manifests/base/deployment-config.yaml
@@ -8,12 +8,16 @@ spec:
   test: false
   replicas: 1
   selector:
+    app.kubernetes.io/name: peribolos-as-service
     app.kubernetes.io/component: peribolos
     app.kubernetes.io/managed-by: sig-services
     service: peribolos-as-service
   template:
     metadata:
+      annotations:
+        alpha.image.policy.openshift.io/resolve-names: '*'
       labels:
+        app.kubernetes.io/name: peribolos-as-service
         app.kubernetes.io/component: peribolos
         app.kubernetes.io/managed-by: sig-services
         service: peribolos-as-service

--- a/manifests/base/imagestream.yaml
+++ b/manifests/base/imagestream.yaml
@@ -4,11 +4,5 @@ kind: ImageStream
 metadata:
   name: peribolos-service-controller
 spec:
-  tags:
-  - from:
-      kind: DockerImage
-      name: quay.io/open-services-group/peribolos-as-a-service:0.0.0
-    importPolicy: {}
-    name: latest
-    referencePolicy:
-      type: Source
+  lookupPolicy:
+    local: true

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -4,14 +4,14 @@ kind: Kustomization
 resources:
   - deployment-config.yaml
   - imagestream.yaml
-  - route.yaml
-  - service.yaml
-  - service-account.yaml
-  - role.yaml
-  - role-binding.yaml
-  - config-dump.yaml
+  - peribolos-dump-config.yaml
   - peribolos-run.yaml
+  - role-binding.yaml
+  - role.yaml
+  - route.yaml
   - secret.yaml
+  - service-account.yaml
+  - service.yaml
 commonLabels:
   app.kubernetes.io/name: peribolos-as-service
   app.kubernetes.io/component: peribolos

--- a/manifests/overlays/dev/imagestream.yaml
+++ b/manifests/overlays/dev/imagestream.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: peribolos-service-controller
+spec:
+  tags:
+  - from:
+      kind: DockerImage
+      name: quay.io/open-services-group/peribolos-as-a-service:v0.0.1
+    importPolicy: {}
+    name: latest
+    referencePolicy:
+      type: Source

--- a/manifests/overlays/dev/kustomization.yaml
+++ b/manifests/overlays/dev/kustomization.yaml
@@ -2,7 +2,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
+  - ../../base
+patchesStrategicMerge:
+  - imagestream.yaml
 patches:
   - patch: |-
       - op: replace

--- a/manifests/overlays/prod/imagestream.yaml
+++ b/manifests/overlays/prod/imagestream.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: peribolos-service-controller
+spec:
+  tags:
+  - from:
+      kind: DockerImage
+      name: quay.io/open-services-group/peribolos-as-a-service:v0.0.1
+    importPolicy: {}
+    name: latest
+    referencePolicy:
+      type: Source

--- a/manifests/overlays/prod/kustomization.yaml
+++ b/manifests/overlays/prod/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+patchesStrategicMerge:
+  - imagestream.yaml
+images:
+  - name: peribolos-service-controller
+    newName: image-registry.openshift-image-registry.svc:5000/peribolos-as-a-service/peribolos-service-controller
+    newTag: latest

--- a/manifests/overlays/test/kustomization.yaml
+++ b/manifests/overlays/test/kustomization.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- ../../base


### PR DESCRIPTION
Fix the image patch in CI
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


Fixes: https://github.com/open-services-group/peribolos-as-a-service/issues/52

This would help with the deployment. 
- the image patch is added, as the openshift is unable to recognize the imagestream name. https://github.com/thoth-station/thoth-application/issues/1996#issuecomment-936561835
- this would automate the update of the imagestream by CI when next release is made.
- context path for the overlays was changed and this would fix it.
- fixed the name of files in kustomize resources. 

