### PR TITLE
chore(renovate): Make renovate sign off commits

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
     "extends": [
-        "config:js-app"
+        "config:js-app",
+        ":gitSignOff"
     ]
 }


### PR DESCRIPTION
Renovate is not signing off commits by default making DCO check fail. This should fix it.