### PR TITLE
chore(renovate): Make renovate group deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,12 @@
 {
     "extends": [
         "config:js-app",
-        ":gitSignOff"
-    ]
+        ":gitSignOff",
+        "group:allNonMajor",
+        "group:linters",
+        "group:semantic-releaseMonorepo",
+    ],
+    "npm": {
+        "stabilityDays": 3
+    }
 }


### PR DESCRIPTION
Let's group all non major upgrades to single PR (excluding linters and semantic release so it doesn't cause troubles). Also introduce stability index for NPM to avoid unpublished releases.