### PR TITLE
chore(ci): Expire commit tagged images in a week

### DIFF
--- a/.github/actions/set-expiration/action.yaml
+++ b/.github/actions/set-expiration/action.yaml
@@ -1,0 +1,26 @@
+name: Set Quay.io image expiration
+description: Set Quay.io image expiration
+inputs:
+  tag:
+    description: Tag to be updated
+    required: true
+  expiration:
+    description: Date parameter passed as date -d, set to false if you want to unset expiration
+  repository:
+    description: Quay.io repository in format org/repo
+    required: true
+  token:
+    description: Quay.io OAuth token
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Set Quay.io image expiration
+      shell: bash
+      run: |
+        [ "${{ inputs.expiration }}" = "false" ] && expiration=null || expiration=$(date +"%s" -d "${{ inputs.expiration }}")
+        curl -X PUT \
+             -d "{\"expiration\":$expiration}" \
+             -H 'Content-Type: application/json' \
+             -H "Authorization: Bearer ${{ inputs.token }}" \
+             https://quay.io/api/v1/repository/${{ inputs.repository }}/tag/${{ inputs.tag }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -38,6 +38,14 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
+      - name: Set expiration
+        uses: ./.github/actions/set-expiration
+        with:
+          repository: open-services-group/peribolos-as-a-service
+          tag: ${{ github.sha }}
+          expiration: +1 week
+          token: ${{ secrets.QUAY_OAUTH_TOKEN }}
+
   build-peribolos:
     name: Build and Push Peribolos
     runs-on: ubuntu-latest
@@ -59,3 +67,11 @@ jobs:
           registry: quay.io/open-services-group
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Set expiration
+        uses: ./.github/actions/set-expiration
+        with:
+          repository: open-services-group/peribolos
+          tag: ${{ github.sha }}
+          expiration: +1 week
+          token: ${{ secrets.QUAY_OAUTH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -205,6 +205,14 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
+      - name: Set expiration
+        uses: ./.github/actions/set-expiration
+        with:
+          repository: open-services-group/peribolos-as-a-service
+          tag: ${{ github.sha }}
+          expiration: +1 week
+          token: ${{ secrets.QUAY_OAUTH_TOKEN }}
+
       - name: Update comment
         uses: peter-evans/create-or-update-comment@v2
         if: ${{ always() }}
@@ -243,6 +251,14 @@ jobs:
           registry: quay.io/open-services-group
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Set expiration
+        uses: ./.github/actions/set-expiration
+        with:
+          repository: open-services-group/peribolos
+          tag: ${{ github.sha }}
+          expiration: +1 week
+          token: ${{ secrets.QUAY_OAUTH_TOKEN }}
 
       - name: Update comment
         uses: peter-evans/create-or-update-comment@v2


### PR DESCRIPTION
While commit heads are nice to keep around in the container repository, we don't need to archive image for every commit forever. Let's expire commit hash tagger images in 1 week, that should be enough time to test things out and potentially revert in stage if necessary.

Expiration can be always modified in Quay UI. 