### PR TITLE
fix: Cleanup some labels in deployment manifests

### DIFF
--- a/manifests/base/controller/deployment.yaml
+++ b/manifests/base/controller/deployment.yaml
@@ -6,10 +6,11 @@ metadata:
 spec:
   replicas: 1
   selector:
-    app.kubernetes.io/component: controller
+    matchLabels:
+      app.kubernetes.io/component: controller
   template:
     metadata:
-      commonLabels:
+      labels:
         app.kubernetes.io/component: controller
     spec:
       serviceAccountName: peribolos-controller


### PR DESCRIPTION
Some nonsense labels were left in the Deployment manifest.