### PR TITLE
feat: Use custom host for peribolos

### DIFF
--- a/manifests/base/controller/route.yaml
+++ b/manifests/base/controller/route.yaml
@@ -3,8 +3,6 @@ kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
   name: controller
-  annotations:
-    kubernetes.io/tls-acme: "true"
 spec:
   to:
     kind: Service

--- a/manifests/overlays/prod/kustomization.yaml
+++ b/manifests/overlays/prod/kustomization.yaml
@@ -8,6 +8,8 @@ configurations:
 generators:
   - .ksops.yaml
 namespace: peribolos-as-a-service
+patchesStrategicMerge:
+  - route.yaml
 images:
   - name: quay.io/open-services-group/peribolos-as-a-service
     newTag: v0.0.1

--- a/manifests/overlays/prod/route.yaml
+++ b/manifests/overlays/prod/route.yaml
@@ -1,0 +1,9 @@
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: controller
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  host: peribolos.operate-first.cloud

--- a/manifests/overlays/stage/kustomization.yaml
+++ b/manifests/overlays/stage/kustomization.yaml
@@ -8,6 +8,8 @@ configurations:
 generators:
   - .ksops.yaml
 namespace: peribolos-as-a-service-stage
+patchesStrategicMerge:
+  - route.yaml
 images:
   - name: quay.io/open-services-group/peribolos-as-a-service
     newTag: v0.0.1

--- a/manifests/overlays/stage/route.yaml
+++ b/manifests/overlays/stage/route.yaml
@@ -1,0 +1,9 @@
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: controller
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  host: peribolos-stage.operate-first.cloud


### PR DESCRIPTION
#103 failed due to https://support.cpanel.net/hc/en-us/articles/4405807056023-Let-s-Encrypt-NewOrder-request-did-not-include-a-SAN-short-enough-to-fit-in-CN- error on the ACME operator.

We need shorter hosts for https.