### PR TITLE
chore(renovate): Disable kustomize and enable GH actions grouping

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,5 +8,19 @@
     ],
     "npm": {
         "stabilityDays": 3
-    }
+    },
+    "packageRules": [
+        {
+            "matchManagers": [
+                "kustomize"
+            ],
+            "enabled": false
+        },
+        {
+            "matchManagers": [
+                "github-actions"
+            ],
+            "groupName": "GitHub Actions"
+        }
+    ]
 }


### PR DESCRIPTION
1. To avoid automatic creation of #108 and #109 we should disable manager for `kustomize`.
2. Group all GH Action version bumps like #96 #97 