### PR TITLE
fix(peribolos): Swap base image so we get SSL

### DIFF
--- a/manifests/base/tasks/dump-config.yaml
+++ b/manifests/base/tasks/dump-config.yaml
@@ -81,6 +81,7 @@ spec:
         git checkout -b $BRANCH_NAME
 
         cp /mnt/shared/peribolos.yaml .
+        yq e -i '{ "orgs": {"tumido-test": .}}' peribolos.yaml
 
         echo "Commiting config to $BRANCH_NAME branch ..."
         git add peribolos.yaml

--- a/manifests/base/tasks/run.yaml
+++ b/manifests/base/tasks/run.yaml
@@ -5,20 +5,18 @@ metadata:
   name: run
 spec:
   params:
-  - name: REPO_NAME
-    type: string
-    default: '.github'
-  - name: INSTALLATION_ID
-    type: string
+    - name: REPO_NAME
+      type: string
+      default: ".github"
+    - name: INSTALLATION_ID
+      type: string
   steps:
     - name: apply-peribolos
       image: toolbox
+      volumeMounts:
+        - mountPath: /mnt/secret
+          name: github-token
       env:
-        - name: GITHUB_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: peribolos-$(params.INSTALLATION_ID)
-              key: token
         - name: ORG_NAME
           valueFrom:
             secretKeyRef:
@@ -32,9 +30,14 @@ spec:
         git clone https://github.com/$ORG_NAME/$(params.REPO_NAME)
         cd $(params.REPO_NAME)
 
-        # Save token to file
-        echo $GITHUB_TOKEN > token
-
         # Run Peribolos on the repository
         echo "Running peribolos..."
-        peribolos --config-path peribolos.yaml --github-token-path token --fix-org --fix-repos --fix-team-members --fix-teams --fix-team-repos --confirm
+        peribolos --config-path peribolos.yaml --github-token-path /mnt/secret/token --fix-org --fix-repos --fix-team-members --fix-teams --fix-team-repos --confirm
+  volumes:
+    - name: github-token
+      secret:
+        secretName: peribolos-$(params.INSTALLATION_ID)
+        items:
+          - key: token
+            path: token
+        optional: false

--- a/peribolos-fix/Dockerfile
+++ b/peribolos-fix/Dockerfile
@@ -7,9 +7,9 @@ WORKDIR /peribolos
 RUN curl -L https://github.com/kubernetes/test-infra/tarball/$COMMIT | tar -xz --strip-components=1
 COPY peribolos.patch prow/cmd/peribolos
 RUN cd prow/cmd/peribolos && \
-patch -f -u main.go -i peribolos.patch && \
-CGO_ENABLED=0 go build -o /usr/bin/peribolos
+    patch -f -u main.go -i peribolos.patch && \
+    CGO_ENABLED=0 go build -o /usr/bin/peribolos
 
-FROM registry.access.redhat.com/ubi8-micro
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 COPY --from=builder /usr/bin/peribolos /usr/bin/peribolos


### PR DESCRIPTION
SSIA, there were issues with certs in the peribolos container so we're switching to ubi-minimal instead of micro, and some minor changes to the tasks so the manifest generated by the dump task can actually be applied...