### PR TITLE
:bar_chart: introduce metrics for the peribolos app

### DIFF
--- a/Metrics.md
+++ b/Metrics.md
@@ -1,0 +1,202 @@
+# Metric Collection
+
+The purpose of this markdown is to collect and aggregate the different metrics we would like to measure for analyzing different aspects of the Peribolos-as-a-Service.
+These metrics should help us answer some of the questions like how many users are interacting with the app, what is the performance of the app etc.
+
+The metrics are defined by the different personas. Based on the different personas different kinda metrics might be interesting.
+We have listed the different personas in the following [subsection](#personas) and metrics that would be interesting based on these personas.
+
+## Personas
+
+-----------
+This doc describes the different personas that are involved in Project Peribolos-as-a-Service.
+
+### Product Owner
+
+Project's key stakeholder who communicate the vision of the product to the team/stakeholders and ensure the feasibility of the product with respect to business objectives.
+
+### Operations
+
+Primarily focused on application management, application maintenance and instrumental in automation of application development processes.
+
+### Technical Architect
+
+Provides technical feasibility of requirements, advise on technology choices and manage the technical roadmap i.e. Team Comet members.
+
+### Analyst
+
+Work with both developers and users to assess the product, utilizing data and user feedback to suggest improvements. Responsible for analyzing metrics to continually improve the product i.e. Team Telescope members.
+
+### Users
+
+Users interacting with the product (who we are building the product for).
+
+-----------
+
+## Metrics Grouped by Personas
+
+Based on the different personas involved in Project Peribolos-as-a-Service and identified [here](#personas), we can categorize the metrics as follows:
+
+<table>
+  <tr>
+   <td><strong>Metrics</strong>
+   </td>
+   <td><strong>Metric Definition</strong>
+   </td>
+   <td><strong>Metric Calculation</strong>
+   </td>
+   <td><strong>Targeted Persona</strong>
+   </td>
+   <td><strong>Data Source</strong>
+   </td>
+  </tr>
+  <tr>
+   <td><strong># New users (daily/weekly/monthly)</strong>
+   </td>
+   <td>Number of new users over time
+   </td>
+   <td>
+   </td>
+   <td>Product Owner
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td><strong>Product Adoption rate
+</strong>
+   </td>
+   <td>How many people adopt the product and become regular users
+   </td>
+   <td>(New Users ÷ Total Users) * 100
+   </td>
+   <td>Product Owner
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td><strong>User Retention Rate</strong>
+   </td>
+   <td>Rate of users retained over time
+   </td>
+   <td>(# Users end of given period)-(# New users acquired in the period) / (#Users in the beginning of the period) * 100
+   </td>
+   <td>Product Owner
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td><strong>Daily/Monthly Active repos (DAU/MAU)</strong>
+   </td>
+   <td>Number of active repos daily/monthly
+   </td>
+   <td>
+   </td>
+   <td>Product Owner
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td><strong>Product Stickiness Ratio</strong>
+   </td>
+   <td>Measures the number of people that are highly engaged with the product
+   </td>
+   <td>(DAU) / (MAU) * 100
+   </td>
+   <td>Product Owner
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td><strong>Product Engagement Score (PES)</strong>
+   </td>
+   <td>How users are interacting with your product
+   </td>
+   <td>(Adoption + Retention + DAU/MAU) / 3 *100
+   </td>
+   <td>Product Owner
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td><strong>Customer Satisfaction Score (CSAT)</strong>
+   </td>
+   <td>How satisfied a customer/user is with overall experience of product
+   </td>
+   <td>User provides rating on a 1-5 level (1 unsatisfied, 5 highly satisfied) \
+ \
+Avg of 1-5 scores <strong>or</strong>
+<p>
+(# 4-5 scores)/(Total response volume) * 100
+   </td>
+   <td>Analyst
+   </td>
+   <td>Feedback Survey
+   </td>
+  </tr>
+  <tr>
+   <td><strong>Availability</strong>
+   </td>
+   <td>Probability that the product is operational at a given time
+   </td>
+   <td>(Time product is operating) / (total time it should be operating)
+   </td>
+   <td>Operations
+   </td>
+   <td>Prometheus
+   </td>
+  </tr>
+  <tr>
+   <td><strong>Avg Response Time</strong>
+   </td>
+   <td>Total time it takes to respond to a request for the app service
+   </td>
+   <td>(Total time taken to respond during the selected time period) / (# Responses in the selected time period)
+   </td>
+   <td>Operations
+   </td>
+   <td>Prometheus
+   </td>
+  </tr>
+  <tr>
+   <td><strong># API request per minute (RPM)</strong>
+   </td>
+   <td>
+   </td>
+   <td>
+   </td>
+   <td>Operations
+   </td>
+   <td>Prometheus
+   </td>
+  </tr>
+  <tr>
+   <td><strong>Success Rate per Action</strong>
+   </td>
+   <td>Success rate per action performed by the app
+   </td>
+   <td>(Success rate/per action)
+   </td>
+   <td> Operations
+   </td>
+   <td>Prometheus
+   </td>
+  </tr>
+  <tr>
+   <td><strong>Failure Rate per Action</strong>
+   </td>
+   <td>Failure rate per action performed by the app
+   </td>
+   <td>(Failure rate/per action)
+   </td>
+   <td> Operations
+   </td>
+   <td>Prometheus
+   </td>
+  </tr>
+</table>

--- a/manifests/base/controller/kustomization.yaml
+++ b/manifests/base/controller/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - secret.yaml
 - serviceaccount.yaml
 - service.yaml
+- servicemonitor.yaml
 namePrefix: peribolos-
 configurations:
 - .transformers.yaml

--- a/manifests/base/controller/servicemonitor.yaml
+++ b/manifests/base/controller/servicemonitor.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: controller-monitor
+spec:
+  endpoints:
+    - path: /metrics
+      port: webhook
+      scheme: http
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@kubernetes/client-node": "0.16.3",
-        "probot": "12.2.3"
+        "probot": "12.2.3",
+        "prom-client": "^14.0.1"
       },
       "devDependencies": {
         "@semantic-release/changelog": "6.0.1",
@@ -3023,6 +3024,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha512-tbaUB1QpTIj4cKY8c1rvNAvEQXA+ekzHmbe4jzNfW3QWsF9GnnP/BRWyl6/qqS53heoYJ93naaFcm/jooONH8g=="
     },
     "node_modules/body-parser": {
       "version": "1.19.2",
@@ -11305,6 +11311,17 @@
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
       "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
     },
+    "node_modules/prom-client": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.0.1.tgz",
+      "integrity": "sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==",
+      "dependencies": {
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -12848,6 +12865,14 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "dependencies": {
+        "bintrees": "1.0.1"
       }
     },
     "node_modules/temp-dir": {
@@ -16153,6 +16178,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha512-tbaUB1QpTIj4cKY8c1rvNAvEQXA+ekzHmbe4jzNfW3QWsF9GnnP/BRWyl6/qqS53heoYJ93naaFcm/jooONH8g=="
     },
     "body-parser": {
       "version": "1.19.2",
@@ -22370,6 +22400,14 @@
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
       "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
     },
+    "prom-client": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.0.1.tgz",
+      "integrity": "sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -23556,6 +23594,14 @@
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
+      }
+    },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "requires": {
+        "bintrees": "1.0.1"
       }
     },
     "temp-dir": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@kubernetes/client-node": "0.16.3",
-    "probot": "12.2.3"
+    "probot": "12.2.3",
+    "prom-client": "^14.0.1"
   },
   "devDependencies": {
     "@semantic-release/changelog": "6.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,40 @@
-import { run } from 'probot';
+import { Server, Probot } from 'probot';
 import app from './app';
+import { register } from 'prom-client';
 
-run(app);
+async function startServer() {
+  const probotDefault = Probot.defaults({
+    appId: process.env.APP_ID,
+    privateKey: process.env.PRIVATE_KEY,
+    secret: process.env.WEBHOOK_SECRET,
+  });
+
+  const server =
+    process.env.NODE_ENV === 'production'
+      ? new Server({
+          Probot: probotDefault,
+        })
+      : new Server({
+          webhookProxy: process.env.WEBHOOK_PROXY_URL,
+          Probot: probotDefault,
+        });
+
+  await server.load(app);
+
+  server.expressApp.get('/', (_, response) => {
+    response.redirect('https://github.com/apps/peribolos');
+  });
+
+  server.expressApp.get('/metrics', async (_, response) => {
+    response.setHeader('Content-type', register.contentType);
+    response.end(await register.metrics());
+  });
+
+  server.expressApp.get('/healthz', (_, response) =>
+    response.status(200).send('OK')
+  );
+
+  server.start();
+}
+
+startServer();

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,53 @@
+import { collectDefaultMetrics, Counter, register } from 'prom-client';
+
+if (process.env.NODE_ENV === 'production') {
+  register.clear();
+  collectDefaultMetrics({ prefix: 'peribolos_' });
+}
+
+export const numberOfInstallTotal =
+  (register.getSingleMetric(
+    'peribolos_num_of_install_total'
+  ) as Counter<string>) ||
+  new Counter({
+    name: 'peribolos_num_of_install_total',
+    help: 'Total number of installs received',
+    labelNames: [],
+  });
+
+export const numberOfUninstallTotal =
+  (register.getSingleMetric(
+    'peribolos_num_of_uninstall_total'
+  ) as Counter<string>) ||
+  new Counter({
+    name: 'peribolos_num_of_uninstall_total',
+    help: 'Total number of uninstalls received',
+    labelNames: [],
+  });
+
+export const numberOfActionsTotal =
+  (register.getSingleMetric(
+    'peribolos_num_of_actions_total'
+  ) as Counter<string>) ||
+  new Counter({
+    name: 'peribolos_num_of_actions_total',
+    help: 'Total number of actions received',
+    labelNames: ['install', 'action'],
+  });
+
+export const operationsTriggered =
+  (register.getSingleMetric(
+    'peribolos_operations_triggered'
+  ) as Counter<string>) ||
+  new Counter({
+    name: 'peribolos_operations_triggered',
+    help: 'Metrics for action triggered by the operator with respect to the kubernetes operations.',
+    labelNames: ['install', 'operation', 'status', 'method'],
+  });
+
+export default {
+  numberOfInstallTotal,
+  numberOfUninstallTotal,
+  numberOfActionsTotal,
+  operationsTriggered,
+};


### PR DESCRIPTION
introduce metrics for the peribolos app
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Related-to: https://github.com/open-services-group/peribolos-as-a-service/issues/58
https://github.com/open-services-group/peribolos-as-a-service/issues/59

- Created metrics.md inspired from https://github.com/AICoE/meteor/blob/main/docs/metrics.md
- Used Server method from probot instead of run, for custom route like `/metrics`
- Included a few metrics for peribolos for num of installation, uninstallation, current no of user serving, operation results
- include `any` type for the variable it was prompting.


Tested on local:
![peribolos-metrics](https://user-images.githubusercontent.com/14028058/168921127-1798bede-efaa-4b03-a1dd-a7eb270ddd25.png)
